### PR TITLE
Detect language from user choice and not browser.

### DIFF
--- a/ding_frontend.strongarm.inc
+++ b/ding_frontend.strongarm.inc
@@ -80,12 +80,11 @@ function ding_frontend_strongarm() {
       ),
       'file' => 'includes/locale.inc',
     ),
-    'locale-browser' => array(
+    'locale-user' => array(
       'callbacks' => array(
-        'language' => 'locale_language_from_browser',
+        'language' => 'locale_language_from_user',
       ),
       'file' => 'includes/locale.inc',
-      'cache' => 0,
     ),
     'language-default' => array(
       'callbacks' => array(


### PR DESCRIPTION
Har lavet en cherry pick på denne ændring fra DBCDKs ding_frontend artois branch.
Syntes den hørte hjemme i Ding2 Core.
