### PR TITLE
Issue #369 - Fixed drush problem with patch to dynamic background in makefile

### DIFF
--- a/ding_frontend.make
+++ b/ding_frontend.make
@@ -14,13 +14,12 @@ projects[ctools][version] = "1.5"
 projects[conditional_styles][subdir] = "contrib"
 projects[conditional_styles][version] = "2.2"
 
-projects[dynamic_background][subdir] = "contrib"
-projects[dynamic_background][version] = "2.0-rc4"
-// Ensures that file upload patch is created on file upload. It normally
+// The patch ensures that file upload patch is created on file upload. It normally
 // created on settings form save, but as we use feature this do not work.
 // See https://www.drupal.org/node/2410241
+projects[dynamic_background][subdir] = "contrib"
+projects[dynamic_background][version] = "2.0-rc4"
 projects[dynamic_background][patch][] = "https://www.drupal.org/files/issues/create_file_path-2410241-1.patch"
-
 
 projects[features][subdir] = "contrib"
 projects[features][version] = "2.0"


### PR DESCRIPTION
For unknown reason the patch to dynamic background is not applied when the comment is above the patch line? 