### PR TITLE
Make taxonomy menu term optional

### DIFF
--- a/plugins/content_types/taxonomy_menu.inc
+++ b/plugins/content_types/taxonomy_menu.inc
@@ -16,7 +16,7 @@ $plugin = array(
   'render callback' => 'ding_frontend_taxonomy_menu_content_type_render',
   'category' => t('Ding!'),
   'required context' => array(
-    new ctools_context_required(t('Taxonomy term id'), array('term', 'taxonomy_term')),
+    new ctools_context_optional(t('Taxonomy term id'), array('term', 'taxonomy_term')),
     new ctools_context_optional(t('Group'), 'node'),
   ),
   'defaults' => array(


### PR DESCRIPTION
There is no reason to require it. It works just as well without.

This is a minor technical issue, so I do not think there is a point to create a new issue for this.

The change will not affect existing usage of the pane.