### PR TITLE
Bug #704: Enabled translation of taxonomy name when used in a dropdown menu

### DIFF
--- a/plugins/content_types/taxonomy_menu.inc
+++ b/plugins/content_types/taxonomy_menu.inc
@@ -108,7 +108,7 @@ function ding_frontend_taxonomy_menu_content_type_render($subtype, $conf, $panel
 
   // Use the items generated to format the block content.
   if ($conf['dropdown']) {
-    $block->content = drupal_get_form('ding_frontend_taxonomy_menu_select_dropdown', $items, $default_value, $vocab->name);
+    $block->content = drupal_get_form('ding_frontend_taxonomy_menu_select_dropdown', $items, $default_value, t($vocab->name));
   }
   else {
     // Return render array with item list as theme function.


### PR DESCRIPTION
Enabled translation of taxonomy name when used in a Ding taxonomy menu with a dropdown configuration enabled.

http://platform.dandigbib.org/issues/704